### PR TITLE
Dockerfile: use scratch base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,32 @@
 FROM golang:1.19-bullseye AS builder
 
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid 65532 \
+    small-user
+
 WORKDIR /go/src/app
-COPY go.* ./
+
+COPY . .
+
 RUN go mod download
+RUN go mod verify
 
-COPY cmd/ ./cmd/
-#COPY internal/ ./internal/     # uncomment when development starts
-RUN mkdir bin/ && go build -o bin/ ./cmd/...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/ ./cmd/...
 
-FROM debian:buster-slim
+FROM scratch
 
-RUN apt update && apt-get install -y ca-certificates && update-ca-certificates
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
 COPY --from=builder /go/src/app/bin/cmd /go/bin/api
+
+USER small-user:small-user
 
 EXPOSE 80/tcp
 ENTRYPOINT ["/go/bin/api"]


### PR DESCRIPTION
Makes the dockerfile 10 times smaller.